### PR TITLE
[fix] Correct Docker `latest` tag logic in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=raw,value=latest,enable=true
           labels: |
             org.opencontainers.image.description=A Rust-powered Top-Cap web game.
             org.opencontainers.image.licenses=MIT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Your bug fixes go here.
 
+## [1.0.0-alpha.3] - 2025-08-17
+
+### Fixed
+
+- **Docker Release Workflow:** Fixed an issue where the `latest` tag was not being applied to the Docker image on tag push, leading to a `manifest unknown` error in the GitHub Container Registry. The `docker/metadata-action` step has been corrected to ensure the `latest` tag is always applied when a new version tag is pushed.
+
 ## [1.0.0-alpha.2] - 2025-08-17
 
 ### Changed


### PR DESCRIPTION
Fixes the issue where the `latest` tag was not being applied to the Docker image on tag push.

The `docker/metadata-action` step had a flawed condition for applying the `latest` tag. The original logic checked for a default branch push (`refs/heads/main`), which would never be true in a tag-triggered workflow (`refs/tags/v*.*.*`).

This commit corrects the logic by forcing the `latest` tag to be applied on every tag-based release, ensuring that the image manifest is correctly created and the `latest` version is always available in the GitHub Container Registry.